### PR TITLE
Mark `RegEx` type as deprecated in favor of stdlib `Regex`

### DIFF
--- a/Sources/TSCBasic/RegEx.swift
+++ b/Sources/TSCBasic/RegEx.swift
@@ -12,6 +12,7 @@ import Foundation
 
 /// A helpful wrapper around NSRegularExpression.
 /// - SeeAlso: NSRegularExpression
+@available(*, deprecated, message: "Use Swift `Regex` type instead")
 public struct RegEx {
     private let regex: NSRegularExpression
     public typealias Options = NSRegularExpression.Options


### PR DESCRIPTION
Users should migrate to Swift stdlib `Regex` type instead.