### PR TITLE
Import new Android overlay

### DIFF
--- a/Sources/TSCLibc/libc.swift
+++ b/Sources/TSCLibc/libc.swift
@@ -15,6 +15,8 @@
 #elseif os(Windows)
 @_exported import CRT
 @_exported import WinSDK
+#elseif canImport(Android)
+@_exported import Android
 #else
 @_exported import Darwin.C
 #endif

--- a/Sources/TSCUtility/FSWatch.swift
+++ b/Sources/TSCUtility/FSWatch.swift
@@ -54,7 +54,7 @@ public class FSWatch {
         self._watcher = NoOpWatcher(paths: paths, latency: latency, delegate: _WatcherDelegate(block: block))
       #elseif os(Windows)
         self._watcher = RDCWatcher(paths: paths, latency: latency, delegate: _WatcherDelegate(block: block))
-      #elseif canImport(Glibc) || canImport(Musl)
+      #elseif canImport(Glibc) || canImport(Musl) || canImport(Android)
         var ipaths: [AbsolutePath: Inotify.WatchOptions] = [:]
 
         // FIXME: We need to recurse here.
@@ -106,7 +106,7 @@ extension NoOpWatcher: _FileWatcher{}
 #elseif os(Windows)
 extension FSWatch._WatcherDelegate: RDCWatcherDelegate {}
 extension RDCWatcher: _FileWatcher {}
-#elseif canImport(Glibc) || canImport(Musl)
+#elseif canImport(Glibc) || canImport(Musl) || canImport(Android)
 extension FSWatch._WatcherDelegate: InotifyDelegate {}
 extension Inotify: _FileWatcher{}
 #elseif os(macOS)
@@ -296,7 +296,7 @@ public final class RDCWatcher {
     }
 }
 
-#elseif canImport(Glibc) || canImport(Musl)
+#elseif canImport(Glibc) || canImport(Musl) || canImport(Android)
 
 /// The delegate for receiving inotify events.
 public protocol InotifyDelegate {

--- a/Sources/TSCUtility/Tracing.swift
+++ b/Sources/TSCUtility/Tracing.swift
@@ -92,7 +92,7 @@ public struct TracingEvent: TracingEventProtocol, Codable, Sendable {
         self.ts = ts
         self.startTs = startTs
     }
-    #elseif canImport(Glibc)
+    #elseif canImport(Glibc) || canImport(Android)
     public init(
         cat: String,
         name: String,


### PR DESCRIPTION
This was recently added in swiftlang/swift#72161 and swiftlang/swift#72634. I've been building it with this patch on my daily Android CI since then, finagolfin/swift-android-sdk#151, and natively on Android too.

@bnbarham, should be an easy review.