### PR TITLE
6.0 [windows] path: drop the trailing backslash before invoking PathCchRe…

### DIFF
--- a/Sources/TSCBasic/Path.swift
+++ b/Sources/TSCBasic/Path.swift
@@ -461,7 +461,21 @@ private struct WindowsPath: Path, Sendable {
         let fsr: UnsafePointer<Int8> = self.string.fileSystemRepresentation
         defer { fsr.deallocate() }
 
-        let path: String = String(cString: fsr)
+        var path: String = String(cString: fsr)
+        // PathCchRemoveFileSpec removes trailing '\' for a
+        // path like 'c:\root\path\', which doesn't give us the parent
+        // directory name. Thus, drop the trailing '\' before calling
+        // PathCchRemoveFileSpec.
+        var substring = path[path.startIndex..<path.endIndex]
+        while !substring.isEmpty && substring.utf8.last == UInt8(ascii: "\\") {
+            substring = substring.dropLast()
+        }
+        if !substring.isEmpty && substring.last != ":" {
+            // Drop the trailing '\', unless the string path only
+            // has '\', and unless the slashes are right after the drive letter.
+            path = String(substring)
+        }
+
         return path.withCString(encodedAs: UTF16.self) {
             let data = UnsafeMutablePointer(mutating: $0)
             PathCchRemoveFileSpec(data, path.count)

--- a/Tests/TSCBasicTests/PathTests.swift
+++ b/Tests/TSCBasicTests/PathTests.swift
@@ -131,6 +131,15 @@ class PathTests: XCTestCase {
         XCTAssertEqual(RelativePath("abc").dirname, ".")
         XCTAssertEqual(RelativePath("").dirname, ".")
         XCTAssertEqual(RelativePath(".").dirname, ".")
+#if os(Windows)
+        XCTAssertEqual(AbsolutePath("C:\\a\\b").dirname, "C:\\a")
+        XCTAssertEqual(AbsolutePath("C:\\").dirname, "C:\\")
+        XCTAssertEqual(AbsolutePath("C:\\\\").dirname, "C:\\")
+        XCTAssertEqual(AbsolutePath("C:\\\\\\").dirname, "C:\\")
+        XCTAssertEqual(AbsolutePath("C:\\a\\b\\").dirname, "C:\\a")
+        XCTAssertEqual(AbsolutePath("C:\\a\\b\\\\").dirname, "C:\\a")
+        XCTAssertEqual(AbsolutePath("C:\\a\\").dirname, "C:\\")
+#endif
     }
 
     func testBaseNameExtraction() {


### PR DESCRIPTION
…… (#479)

(cherry picked from commit a76104dbd3c3fff41adb70bc7e917a4b2d076cef)

Explanation: After new swift-foundation was adopted on windows, swiftpm failed to build a project when your SDKROOT environment variable had a trailing '\\' on windows. This was due to Info.plist not being found that was needed for the XCTest include paths. This was because `dirname` on a windows path now returned the original path without going up a level if the path had a trailing '\\' as `PathCchRemoveFileSpec` doesn't remove the dirname in that case. This regression was addressed by dropping the trailing '\' before calling `PathCchRemoveFileSpec`.
Scope: windows path handling, tools like SwiftPM that use TSC.
Risk: Low, only impacts paths that have a trailing '\\'.
Testing: Unit tests, manual testing of SwiftPM locally and in a github workflow
Reviewer: @compnerd 
Main branch PR: https://github.com/swiftlang/swift-tools-support-core/pull/479