### PR TITLE
Fix warnings about extraneous whitespace on @availability.

### DIFF
--- a/Sources/TSCUtility/Netrc.swift
+++ b/Sources/TSCUtility/Netrc.swift
@@ -25,7 +25,7 @@ extension AuthorizationProviding {
 /// Container of parsed netrc connection settings
 // FIXME: deprecate 2/2022, remove once clients transitioned
 @available(*, deprecated, message: "moved to SwiftPM")
-@available (macOS 10.13, iOS 11, tvOS 11, watchOS 4, *)
+@available(macOS 10.13, iOS 11, tvOS 11, watchOS 4, *)
 public struct Netrc {
     /// Representation of `machine` connection settings & `default` connection settings.
     /// If `default` connection settings present, they will be last element.
@@ -97,12 +97,12 @@ public struct Netrc {
 
 // deprecated 9/2021
 @available(*, deprecated)
-@available (macOS 10.13, iOS 11, tvOS 11, watchOS 4, *)
+@available(macOS 10.13, iOS 11, tvOS 11, watchOS 4, *)
 extension Netrc: AuthorizationProviding {}
 
 // FIXME: deprecate 2/2022, remove once clients transitioned
 @available(*, deprecated, message: "moved to SwiftPM")
-@available (macOS 10.13, iOS 11, tvOS 11, watchOS 4, *)
+@available(macOS 10.13, iOS 11, tvOS 11, watchOS 4, *)
 public extension Netrc {
     enum Error: Swift.Error {
         case invalidFilePath
@@ -142,7 +142,7 @@ public extension Netrc {
 
 // FIXME: deprecate 2/2022, remove once clients transitioned
 @available(*, deprecated, message: "moved to SwiftPM")
-@available (macOS 10.13, iOS 11, tvOS 11, watchOS 4, *)
+@available(macOS 10.13, iOS 11, tvOS 11, watchOS 4, *)
 extension Netrc.Error: CustomNSError {
     public var errorUserInfo: [String : Any] {
         return [NSLocalizedDescriptionKey: "\(self)"]
@@ -151,7 +151,7 @@ extension Netrc.Error: CustomNSError {
 
 // FIXME: deprecate 2/2022, remove once clients transitioned
 @available(*, deprecated, message: "moved to SwiftPM")
-@available (macOS 10.13, iOS 11, tvOS 11, watchOS 4, *)
+@available(macOS 10.13, iOS 11, tvOS 11, watchOS 4, *)
 fileprivate enum RegexUtil {
     @frozen fileprivate enum Token: String, CaseIterable {
         case machine, login, password, account, macdef, `default`


### PR DESCRIPTION
The build is generating warnings about extra space after `@availability` and before the `(`.

rdar://133952407