### PR TITLE
Use `readData` to read data from a pipe instead of `availableData`

### DIFF
--- a/Sources/TSCBasic/Process/Process.swift
+++ b/Sources/TSCBasic/Process/Process.swift
@@ -575,7 +575,7 @@ public final class Process {
 
             group.enter()
             stdoutPipe.fileHandleForReading.readabilityHandler = { (fh : FileHandle) -> Void in
-                let data = fh.availableData
+                let data = (try? fh.read(upToCount: Int.max)) ?? Data()
                 if (data.count == 0) {
                     stdoutPipe.fileHandleForReading.readabilityHandler = nil
                     group.leave()
@@ -590,7 +590,7 @@ public final class Process {
 
             group.enter()
             stderrPipe.fileHandleForReading.readabilityHandler = { (fh : FileHandle) -> Void in
-                let data = fh.availableData
+                let data = (try? fh.read(upToCount: Int.max)) ?? Data()
                 if (data.count == 0) {
                     stderrPipe.fileHandleForReading.readabilityHandler = nil
                     group.leave()


### PR DESCRIPTION
Analogous fix to https://github.com/swiftlang/swift-package-manager/pull/8047