### PR TITLE
Add Swift Testing helper functions

### DIFF
--- a/Sources/TSCTestSupport/SwiftTestingHelpers.swift
+++ b/Sources/TSCTestSupport/SwiftTestingHelpers.swift
@@ -1,0 +1,48 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Testing
+
+import TSCBasic
+
+public func expectFileExists(
+    _ path: AbsolutePath,
+    sourceLocation: SourceLocation = #_sourceLocation
+) {
+    print("localFileSystem.isFile(path) ==> \(localFileSystem.isFile(path))")
+    #expect(
+        localFileSystem.isFile(path),
+        "Expected file doesn't exist: \(path)",
+        sourceLocation: sourceLocation
+    )
+}
+public func expectDirectoryExists(
+    _ path: AbsolutePath,
+    sourceLocation: SourceLocation = #_sourceLocation
+) {
+    #expect(
+        localFileSystem.isDirectory(path),
+        "Expected directory doesn't exist: \(path)",
+        sourceLocation: sourceLocation
+    )
+}
+
+public func expectNoDiagnostics(
+    _ engine: DiagnosticsEngine,
+    sourceLocation: SourceLocation = #_sourceLocation
+) {
+    let diagnostics = engine.diagnostics
+    let diags = diagnostics.map({ "- " + $0.description }).joined(separator: "\n")
+    #expect(
+        diagnostics.isEmpty,
+        "Found unexpected diagnostics: \n\(diags)",
+        sourceLocation: sourceLocation
+    )
+}


### PR DESCRIPTION
In the process of converting XCTests to Swift Testing, add a few Swift Testing helper functions equivalent to the XCTest equivalents.

Unfortunately, I'm unable to write automated tests that verify the new helpers behave as expected as the Swift Testing framework does not currently allow writing tests that verify an issue was recorded. This is tracked under https://github.com/swiftlang/swift-testing/issues/155