### PR TITLE
iOS 13 is aligned with macOS 10.15

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,10 +15,16 @@ import PackageDescription
 import class Foundation.ProcessInfo
 
 let macOSPlatform: SupportedPlatform
+let iOSPlatform: SupportedPlatform
 if let deploymentTarget = ProcessInfo.processInfo.environment["SWIFTTSC_MACOS_DEPLOYMENT_TARGET"] {
     macOSPlatform = .macOS(deploymentTarget)
 } else {
     macOSPlatform = .macOS(.v10_15)
+}
+if let deploymentTarget = ProcessInfo.processInfo.environment["SWIFTTSC_IOS_DEPLOYMENT_TARGET"] {
+    iOSPlatform = .iOS(deploymentTarget)
+} else {
+    iOSPlatform = .iOS(.v13)
 }
 
 let CMakeFiles = ["CMakeLists.txt"]
@@ -27,7 +33,7 @@ let package = Package(
     name: "swift-tools-support-core",
     platforms: [
         macOSPlatform,
-        .iOS(.v15)
+        iOSPlatform,
     ],
     products: [
         .library(


### PR DESCRIPTION
The `Package.swift` had misaligned iOS & macOS versions. That's a problem for anything that depends on this as those packages can't usually raise their platform versions as that's SemVer major.