### PR TITLE
Remove referenced projects from multiroot data file

### DIFF
--- a/Utilities/ci.xcworkspace/contents.xcworkspacedata
+++ b/Utilities/ci.xcworkspace/contents.xcworkspacedata
@@ -2,27 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:../../sourcekit-lsp">
-   </FileRef>
-   <FileRef
-      location = "group:../../swift-package-manager">
-   </FileRef>
-   <FileRef
-      location = "group:../../swift-argument-parser">
-   </FileRef>
-   <FileRef
-      location = "group:../../swift-driver">
-   </FileRef>
-   <FileRef
-      location = "group:../../swift-llbuild">
-   </FileRef>
-   <FileRef
-      location = "group:../../yams">
-   </FileRef>
-   <FileRef
-      location = "group:../../indexstore-db">
-   </FileRef>
-   <FileRef
       location = "group:..">
    </FileRef>
 </Workspace>

--- a/Utilities/ci.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Utilities/ci.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,7 +1,0 @@
-{
-  "object": {
-    "pins": [
-    ]
-  },
-  "version": 1
-}


### PR DESCRIPTION
We only build and test swift-tools-support-core with this multiroot-data-file, so there’s no reason why it should include any other projects.

This should fix the CI failures on macOS.