### PR TITLE
Fix FILEPointer typealias for Musl

### DIFF
--- a/Sources/TSCBasic/WritableByteStream.swift
+++ b/Sources/TSCBasic/WritableByteStream.swift
@@ -66,7 +66,7 @@ public extension WritableByteStream {
 // Public alias to the old name to not introduce API compatibility.
 public typealias OutputByteStream = WritableByteStream
 
-#if os(Android) || canImport(Musl)
+#if os(Android)
 public typealias FILEPointer = OpaquePointer
 #else
 public typealias FILEPointer = UnsafeMutablePointer<FILE>


### PR DESCRIPTION
Currently, `FILEPointer` is typealiased to `OpaquePointer` for Musl:

```swift
#if os(Android) || canImport(Musl)
public typealias FILEPointer = OpaquePointer
#else
public typealias FILEPointer = UnsafeMutablePointer<FILE>
#endif
```

But building an executable that links against TSCBasic fails:

```
$ ~/Library/Developer/Toolchains/swift-6.0.1-RELEASE.xctoolchain/usr/bin/swift build --swift-sdk x86_64-swift-linux-musl

.build/checkouts/swift-tools-support-core/Sources/TSCBasic/Process/Process.swift:706:70: error: cannot convert value of type 'UnsafeMutablePointer<FILE>' (aka 'UnsafeMutablePointer<_IO_FILE>') to expected argument type 'FILEPointer' (aka 'OpaquePointer')
 704 |             throw Process.Error.stdinUnavailable
 705 |         }
 706 |         let stdinStream = try LocalFileOutputByteStream(filePointer: fp, closeOnDeinit: true)
     |                                                                      `- error: cannot convert value of type 'UnsafeMutablePointer<FILE>' (aka 'UnsafeMutablePointer<_IO_FILE>') to expected argument type 'FILEPointer' (aka 'OpaquePointer')
```

But removing the `canImport(Musl)` check allows it to compile without issue, so I assume it was put there for an earlier version of the Musl SDK (or that it was never tested).
