### PR TITLE
[6.1] Fix the Android build

### DIFF
--- a/Sources/TSCUtility/Tracing.swift
+++ b/Sources/TSCUtility/Tracing.swift
@@ -9,6 +9,7 @@
  */
 
 import Foundation
+import TSCLibc
 
 public enum TracingEventType: String, Codable, Sendable {
     case asyncBegin


### PR DESCRIPTION
__Explanation:__ This import was missed and the Android cross-compile complains.

__Scope:__ A single import for C functions

__Issue:__ None

__Original PRs:__ #492

__Risk:__ Practically non-existent

__Testing:__ Passed all CI on trunk

__Reviewer:__ @owenv

This pull from @jakepetroules was merged right after the 6.1 branch: I don't want to have to apply it for the 6.1 builds on my Android CI for the next year.