### PR TITLE
build: add additional target exports for static linking

### DIFF
--- a/Sources/TSCLibc/CMakeLists.txt
+++ b/Sources/TSCLibc/CMakeLists.txt
@@ -12,3 +12,5 @@ add_library(TSCLibc STATIC
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(TSCLibc PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+
+set_property(GLOBAL APPEND PROPERTY TSC_EXPORTS TSCLibc)


### PR DESCRIPTION
When building tools-support-core using statically linked libraries, we need to export additional targets to ensure that the full closure is available to consumers.This is meant to support building swift-driver against a statically linked form of tools-support-core to allow using the early swift-driver on Windows.