### PR TITLE
Use C to force the POSIX (not GNU) overload of strerror_r to be selected

### DIFF
--- a/Sources/TSCBasic/CMakeLists.txt
+++ b/Sources/TSCBasic/CMakeLists.txt
@@ -52,8 +52,6 @@ add_library(TSCBasic
   misc.swift)
 
 target_compile_options(TSCBasic PUBLIC
-  # Don't use GNU strerror_r on Android.
-  "$<$<PLATFORM_ID:Android>:SHELL:-Xcc -U_GNU_SOURCE>"
   # Ignore secure function warnings on Windows.
   "$<$<PLATFORM_ID:Windows>:SHELL:-Xcc -D_CRT_SECURE_NO_WARNINGS>")
 target_link_libraries(TSCBasic PRIVATE

--- a/Sources/TSCBasic/misc.swift
+++ b/Sources/TSCBasic/misc.swift
@@ -8,6 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+@_implementationOnly import TSCclibc
 import TSCLibc
 import Foundation
 #if os(Windows)
@@ -327,7 +328,7 @@ extension SystemError: CustomStringConvertible {
             var cap = 64
             while cap <= 16 * 1024 {
                 var buf = [Int8](repeating: 0, count: cap)
-                let err = TSCLibc.strerror_r(errno, &buf, buf.count)
+                let err = TSCclibc.tsc_strerror_r(errno, &buf, buf.count)
                 if err == EINVAL {
                     return "Unknown error \(errno)"
                 }

--- a/Sources/TSCclibc/CMakeLists.txt
+++ b/Sources/TSCclibc/CMakeLists.txt
@@ -7,7 +7,7 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_library(TSCclibc STATIC
-  libc.c process.c)
+  libc.c process.c strerror.c)
 target_include_directories(TSCclibc PUBLIC
   include)
 target_compile_definitions(TSCclibc PRIVATE

--- a/Sources/TSCclibc/include/module.modulemap
+++ b/Sources/TSCclibc/include/module.modulemap
@@ -2,5 +2,6 @@ module TSCclibc {
     header "TSCclibc.h"
     header "indexstore_functions.h"
     header "process.h"
+    header "strerror.h"
     export *
 }

--- a/Sources/TSCclibc/include/strerror.h
+++ b/Sources/TSCclibc/include/strerror.h
@@ -1,0 +1,5 @@
+#include <stddef.h>
+
+#ifndef _WIN32
+extern int tsc_strerror_r(int errnum, char *buf, size_t buflen);
+#endif

--- a/Sources/TSCclibc/strerror.c
+++ b/Sources/TSCclibc/strerror.c
@@ -1,0 +1,9 @@
+#undef _GNU_SOURCE
+#include "strerror.h"
+#include <string.h>
+
+#ifndef _WIN32
+int tsc_strerror_r(int errnum, char *buf, size_t buflen) {
+    return strerror_r(errnum, buf, buflen);
+}
+#endif


### PR DESCRIPTION
This allows building TSC for Android without needing to pass custom flags via -Xcc.