### PR TITLE
Revert "Use C to force the POSIX (not GNU) overload of strerror_r to be selected"

### DIFF
--- a/Sources/TSCBasic/CMakeLists.txt
+++ b/Sources/TSCBasic/CMakeLists.txt
@@ -52,6 +52,8 @@ add_library(TSCBasic
   misc.swift)
 
 target_compile_options(TSCBasic PUBLIC
+  # Don't use GNU strerror_r on Android.
+  "$<$<PLATFORM_ID:Android>:SHELL:-Xcc -U_GNU_SOURCE>"
   # Ignore secure function warnings on Windows.
   "$<$<PLATFORM_ID:Windows>:SHELL:-Xcc -D_CRT_SECURE_NO_WARNINGS>")
 target_link_libraries(TSCBasic PRIVATE

--- a/Sources/TSCBasic/misc.swift
+++ b/Sources/TSCBasic/misc.swift
@@ -8,7 +8,6 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-@_implementationOnly import TSCclibc
 import TSCLibc
 import Foundation
 #if os(Windows)
@@ -328,7 +327,7 @@ extension SystemError: CustomStringConvertible {
             var cap = 64
             while cap <= 16 * 1024 {
                 var buf = [Int8](repeating: 0, count: cap)
-                let err = TSCclibc.tsc_strerror_r(errno, &buf, buf.count)
+                let err = TSCLibc.strerror_r(errno, &buf, buf.count)
                 if err == EINVAL {
                     return "Unknown error \(errno)"
                 }

--- a/Sources/TSCclibc/CMakeLists.txt
+++ b/Sources/TSCclibc/CMakeLists.txt
@@ -7,7 +7,7 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_library(TSCclibc STATIC
-  libc.c process.c strerror.c)
+  libc.c process.c)
 target_include_directories(TSCclibc PUBLIC
   include)
 target_compile_definitions(TSCclibc PRIVATE

--- a/Sources/TSCclibc/include/module.modulemap
+++ b/Sources/TSCclibc/include/module.modulemap
@@ -2,6 +2,5 @@ module TSCclibc {
     header "TSCclibc.h"
     header "indexstore_functions.h"
     header "process.h"
-    header "strerror.h"
     export *
 }

--- a/Sources/TSCclibc/include/strerror.h
+++ b/Sources/TSCclibc/include/strerror.h
@@ -1,5 +1,0 @@
-#include <stddef.h>
-
-#ifndef _WIN32
-extern int tsc_strerror_r(int errnum, char *buf, size_t buflen);
-#endif

--- a/Sources/TSCclibc/strerror.c
+++ b/Sources/TSCclibc/strerror.c
@@ -1,9 +1,0 @@
-#undef _GNU_SOURCE
-#include "strerror.h"
-#include <string.h>
-
-#ifndef _WIN32
-int tsc_strerror_r(int errnum, char *buf, size_t buflen) {
-    return strerror_r(errnum, buf, buflen);
-}
-#endif


### PR DESCRIPTION
Reverts swiftlang/swift-tools-support-core#497

Possibly causing a linker failure.
https://ci.swift.org/job/oss-swift-package-amazon-linux-2/4036/console
```
error: link command failed with exit code 1 (use -v to see invocation)
/usr/bin/ld.gold: error: lib/libTSCclibc.a(strerror.c.o): requires dynamic R_X86_64_PC32 reloc against '__xpg_strerror_r' which may overflow at runtime; recompile with -fPIC
clang-13: error: linker command failed with exit code 1 (use -v to see invocation)
error: fatalError
```