### PR TITLE
Handle strerror_r return type of UnsafeMutablePointer<CChar> for Android

### DIFF
--- a/Sources/TSCBasic/misc.swift
+++ b/Sources/TSCBasic/misc.swift
@@ -327,7 +327,12 @@ extension SystemError: CustomStringConvertible {
             var cap = 64
             while cap <= 16 * 1024 {
                 var buf = [Int8](repeating: 0, count: cap)
+                #if os(Android)
+                let errptr: UnsafeMutablePointer<CChar> = TSCLibc.strerror_r(errno, &buf, buf.count)
+                let err = Int(errptr.pointee)
+                #else
                 let err = TSCLibc.strerror_r(errno, &buf, buf.count)
+                #endif
                 if err == EINVAL {
                     return "Unknown error \(errno)"
                 }


### PR DESCRIPTION
This fixes the Android build error:

```
/opt/src/github/swift-everywhere/swift-tools-support-core/Sources/TSCBasic/misc.swift:331:24: error: binary operator '==' cannot be applied to operands of type 'UnsafeMutablePointer<CChar>' (aka 'UnsafeMutablePointer<Int8>') and 'Int32'
329 |                 var buf = [Int8](repeating: 0, count: cap)
330 |                 let err = TSCLibc.strerror_r(errno, &buf, buf.count)
331 |                 if err == EINVAL {
    |                        |- error: binary operator '==' cannot be applied to operands of type 'UnsafeMutablePointer<CChar>' (aka 'UnsafeMutablePointer<Int8>') and 'Int32'
    |                        `- note: overloads for '==' exist with these partially matching parameter lists: (Int32, Int32)
332 |                     return "Unknown error \(errno)"
333 |                 }

/opt/src/github/swift-everywhere/swift-tools-support-core/Sources/TSCBasic/misc.swift:334:24: error: binary operator '==' cannot be applied to operands of type 'UnsafeMutablePointer<CChar>' (aka 'UnsafeMutablePointer<Int8>') and 'Int32'
332 |                     return "Unknown error \(errno)"
333 |                 }
334 |                 if err == ERANGE {
    |                        |- error: binary operator '==' cannot be applied to operands of type 'UnsafeMutablePointer<CChar>' (aka 'UnsafeMutablePointer<Int8>') and 'Int32'
    |                        `- note: overloads for '==' exist with these partially matching parameter lists: (Int32, Int32)
335 |                     cap *= 2
336 |                     continue

/opt/src/github/swift-everywhere/swift-tools-support-core/Sources/TSCBasic/misc.swift:338:24: error: binary operator '!=' cannot be applied to operands of type 'UnsafeMutablePointer<CChar>' (aka 'UnsafeMutablePointer<Int8>') and 'Int'
336 |                     continue
337 |                 }
338 |                 if err != 0 {
    |                        |- error: binary operator '!=' cannot be applied to operands of type 'UnsafeMutablePointer<CChar>' (aka 'UnsafeMutablePointer<Int8>') and 'Int'
    |                        `- note: overloads for '!=' exist with these partially matching parameter lists: (Int, Int)
339 |                     fatalError("strerror_r error: \(err)")
340 |                 }
```