### PR TITLE
Resolves #505 - Fix handling for Windows long paths

### DIFF
--- a/Sources/TSCBasic/CMakeLists.txt
+++ b/Sources/TSCBasic/CMakeLists.txt
@@ -49,7 +49,8 @@ add_library(TSCBasic
   TerminalController.swift
   Thread.swift
   Tuple.swift
-  misc.swift)
+  misc.swift
+  Win32Error.swift)
 
 target_compile_options(TSCBasic PUBLIC
   # Ignore secure function warnings on Windows.

--- a/Sources/TSCBasic/Win32Error.swift
+++ b/Sources/TSCBasic/Win32Error.swift
@@ -1,0 +1,37 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+#if os(Windows)
+public import WinSDK
+import Foundation
+
+public struct Win32Error: Error, CustomStringConvertible {
+    public let error: DWORD
+
+    public init(_ error: DWORD) {
+        self.error = error
+    }
+
+    public var description: String {
+        let flags: DWORD = DWORD(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS)
+        var buffer: UnsafeMutablePointer<WCHAR>?
+        let length: DWORD = withUnsafeMutablePointer(to: &buffer) {
+            $0.withMemoryRebound(to: WCHAR.self, capacity: 2) {
+                FormatMessageW(flags, nil, error, 0, $0, 0, nil)
+            }
+        }
+        guard let buffer, length > 0 else {
+            return "Win32 Error Code \(error)"
+        }
+        defer { LocalFree(buffer) }
+        return String(decodingCString: buffer, as: UTF16.self).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+#endif


### PR DESCRIPTION
 [PR#369](https://github.com/swiftlang/swift-tools-support-core/pull/369)  caused the majority of tests on Windows to fail, as normalization of RelativePath was removed. This change  also removed the call to 'PathAllocCanonicalize' for AbsolutePath which had the long file flag 'PATHCCH_ALLOW_LONG_PATHS'.

Reintroducing canonicalization of AbsolutePath path representation to handle long paths.

-  Update tests dealing with RelativePath to match implementation.
-  Canonicalize the path representation for AbsolutePath which also allows for long path '\\?\' prefix addition when path > 260 in length.
-  Strip trailing backslash on string representation of AbsolutePath to match definition. Only strips for non root paths.
-  Add helper functions: 
    - removeTrailingBackslash
    - stripPrefix
    - canonicalPathRepresentation
- Add Windows API Error helpers
- Add long path tests into each test case
- Ran swift format on code
- Update copyright dates