### PR TITLE
Add in several missing noasync annotations

### DIFF
--- a/Sources/TSCBasic/Await.swift
+++ b/Sources/TSCBasic/Await.swift
@@ -14,16 +14,12 @@
 ///                   should be passed to the async method's completion handler.
 /// - Returns: The value wrapped by the async method's result.
 /// - Throws: The error wrapped by the async method's result
-//#if compiler(>=5.8)
-//@available(*, noasync)
-//#endif
+@available(*, noasync)
 public func tsc_await<T, ErrorType>(_ body: (@escaping (Result<T, ErrorType>) -> Void) -> Void) throws -> T {
     return try tsc_await(body).get()
 }
 
-//#if compiler(>=5.8)
-//@available(*, noasync)
-//#endif
+@available(*, noasync)
 public func tsc_await<T>(_ body: (@escaping (T) -> Void) -> Void) -> T {
     let condition = Condition()
     var result: T? = nil

--- a/Sources/TSCBasic/Process/Process.swift
+++ b/Sources/TSCBasic/Process/Process.swift
@@ -324,6 +324,7 @@ public final class Process {
 
     /// The result of the process execution. Available after process is terminated.
     /// This will block while the process is awaiting result
+    @available(*, noasync)
     @available(*, deprecated, message: "use waitUntilExit instead")
     public var result: ProcessResult? {
         return self.stateLock.withLock {
@@ -856,7 +857,9 @@ public final class Process {
     public func waitUntilExit() async throws -> ProcessResult {
         try await withCheckedThrowingContinuation { continuation in
             DispatchQueue.processConcurrent.async {
-                self.waitUntilExit(continuation.resume(with:))
+                self.waitUntilExit {
+                    continuation.resume(with: $0)
+                }
             }
         }
     }
@@ -1127,9 +1130,7 @@ extension Process {
     ///   - loggingHandler: Handler for logging messages
     ///   - queue: Queue to use for callbacks
     ///   - completion: A completion handler to return the process result
-//    #if compiler(>=5.8)
-//    @available(*, noasync)
-//    #endif
+    @available(*, noasync)
     static public func popen(
         arguments: [String],
         environmentBlock: ProcessEnvironmentBlock = ProcessEnv.block,
@@ -1157,6 +1158,7 @@ extension Process {
     }
 
     @_disfavoredOverload
+    @available(*, noasync)
     @available(*, deprecated, renamed: "popen(arguments:environmentBlock:loggingHandler:queue:completion:)")
     static public func popen(
         arguments: [String],
@@ -1182,9 +1184,7 @@ extension Process {
     ///     will be inherited.
     ///   - loggingHandler: Handler for logging messages
     /// - Returns: The process result.
-//    #if compiler(>=5.8)
-//    @available(*, noasync)
-//    #endif
+    @available(*, noasync)
     @discardableResult
     static public func popen(
         arguments: [String],
@@ -1202,6 +1202,7 @@ extension Process {
     }
 
     @_disfavoredOverload
+    @available(*, noasync)
     @available(*, deprecated, renamed: "popen(arguments:environmentBlock:loggingHandler:)")
     @discardableResult
     static public func popen(
@@ -1220,9 +1221,7 @@ extension Process {
     ///     will be inherited.
     ///   - loggingHandler: Handler for logging messages
     /// - Returns: The process result.
-//    #if compiler(>=5.8)
-//    @available(*, noasync)
-//    #endif
+    @available(*, noasync)
     @discardableResult
     static public func popen(
         args: String...,
@@ -1233,6 +1232,7 @@ extension Process {
     }
 
     @_disfavoredOverload
+    @available(*, noasync)
     @available(*, deprecated, renamed: "popen(args:environmentBlock:loggingHandler:)")
     @discardableResult
     static public func popen(
@@ -1251,9 +1251,7 @@ extension Process {
     ///     will be inherited.
     ///   - loggingHandler: Handler for logging messages
     /// - Returns: The process output (stdout + stderr).
-//    #if compiler(>=5.8)
-//    @available(*, noasync)
-//    #endif
+    @available(*, noasync)
     @discardableResult
     static public func checkNonZeroExit(
         arguments: [String],
@@ -1276,6 +1274,7 @@ extension Process {
     }
 
     @_disfavoredOverload
+    @available(*, noasync)
     @available(*, deprecated, renamed: "checkNonZeroExit(arguments:environmentBlock:loggingHandler:)")
     @discardableResult
     static public func checkNonZeroExit(
@@ -1294,9 +1293,7 @@ extension Process {
     ///     will be inherited.
     ///   - loggingHandler: Handler for logging messages
     /// - Returns: The process output (stdout + stderr).
-//    #if compiler(>=5.8)
-//    @available(*, noasync)
-//    #endif
+    @available(*, noasync)
     @discardableResult
     static public func checkNonZeroExit(
         args: String...,
@@ -1307,6 +1304,7 @@ extension Process {
     }
 
     @_disfavoredOverload
+    @available(*, noasync)
     @available(*, deprecated, renamed: "checkNonZeroExit(args:environmentBlock:loggingHandler:)")
     @discardableResult
     static public func checkNonZeroExit(

--- a/Sources/TSCBasic/Process/ProcessSet.swift
+++ b/Sources/TSCBasic/Process/ProcessSet.swift
@@ -65,9 +65,7 @@ public final class ProcessSet {
     /// Terminate all the processes. This method blocks until all processes in the set are terminated.
     ///
     /// A process set cannot be used once it has been asked to terminate.
-//    #if compiler(>=5.8)
-//    @available(*, noasync)
-//    #endif
+    @available(*, noasync)
     public func terminate() {
         // Mark a process set as cancelled.
         serialQueue.sync {

--- a/Sources/TSCTestSupport/misc.swift
+++ b/Sources/TSCTestSupport/misc.swift
@@ -44,6 +44,8 @@ public func testWithTemporaryDirectory(
     }
 }
 
+@available(*, noasync)
+@available(*, deprecated, message: "Use Process.checkNonZeroExit(arguments:) instead.")
 public func systemQuietly(_ args: [String]) throws {
     // Discard the output, by default.
     //
@@ -51,6 +53,8 @@ public func systemQuietly(_ args: [String]) throws {
     try Process.checkNonZeroExit(arguments: args)
 }
 
+@available(*, noasync)
+@available(*, deprecated, message: "Use Process.checkNonZeroExit(_:) instead.")
 public func systemQuietly(_ args: String...) throws {
     try systemQuietly(args)
 }

--- a/Tests/TSCBasicTests/ProcessTests.swift
+++ b/Tests/TSCBasicTests/ProcessTests.swift
@@ -478,9 +478,7 @@ fileprivate extension Process {
         self.init(arguments: [Self.script(scriptName)] + arguments, environment: Self.env(), outputRedirection: outputRedirection)
     }
 
-//    #if compiler(>=5.8)
-//    @available(*, noasync)
-//    #endif
+    @available(*, noasync)
     static func checkNonZeroExit(
         scriptName: String,
         environment: [String: String] = ProcessEnv.vars,
@@ -498,9 +496,7 @@ fileprivate extension Process {
         return try await checkNonZeroExit(args: script(scriptName), environment: environment, loggingHandler: loggingHandler)
     }
 
-//    #if compiler(>=5.8)
-//    @available(*, noasync)
-//    #endif
+    @available(*, noasync)
     @discardableResult
     static func popen(
         scriptName: String,


### PR DESCRIPTION
Helps make async client code safer by warning about use of blocking overloads.