### PR TITLE
Make SPM_posix_spawn_file_actions_addchdir_np* available on all non-Windows platforms

### DIFF
--- a/Sources/TSCBasic/Process/Process.swift
+++ b/Sources/TSCBasic/Process/Process.swift
@@ -679,24 +679,11 @@ public final class Process {
         defer { posix_spawn_file_actions_destroy(&fileActions) }
 
         if let workingDirectory = workingDirectory?.pathString {
-          #if canImport(Darwin)
-            // The only way to set a workingDirectory is using an availability-gated initializer, so we don't need
-            // to handle the case where the posix_spawn_file_actions_addchdir_np method is unavailable. This check only
-            // exists here to make the compiler happy.
-            if #available(macOS 10.15, *) {
-                posix_spawn_file_actions_addchdir_np(&fileActions, workingDirectory)
-            }
-          #elseif os(FreeBSD)
-                posix_spawn_file_actions_addchdir_np(&fileActions, workingDirectory)
-          #elseif os(Linux)
             guard SPM_posix_spawn_file_actions_addchdir_np_supported() else {
                 throw Process.Error.workingDirectoryNotSupported
             }
 
             SPM_posix_spawn_file_actions_addchdir_np(&fileActions, workingDirectory)
-          #else
-            throw Process.Error.workingDirectoryNotSupported
-          #endif
         }
 
         var stdinPipe: [Int32] = [-1, -1]

--- a/Sources/TSCclibc/include/process.h
+++ b/Sources/TSCclibc/include/process.h
@@ -1,4 +1,4 @@
-#if defined(__linux__)
+#if !defined(_WIN32)
 
 #include <spawn.h>
 #include <stdbool.h>

--- a/Sources/TSCclibc/process.c
+++ b/Sources/TSCclibc/process.c
@@ -1,7 +1,13 @@
-#if defined(__linux__)
+#if !defined(_WIN32)
 
+#if defined(__linux__)
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE /* for posix_spawn_file_actions_addchdir_np */
+#endif
+#endif
+
+#ifndef __GLIBC_PREREQ
+#define __GLIBC_PREREQ(maj, min) 0
 #endif
 
 #include <errno.h>
@@ -9,26 +15,40 @@
 #include "process.h"
 
 int SPM_posix_spawn_file_actions_addchdir_np(posix_spawn_file_actions_t *restrict file_actions, const char *restrict path) {
-#if defined(__GLIBC__)
-#  if __GLIBC_PREREQ(2, 29)
-    return posix_spawn_file_actions_addchdir_np(file_actions, path);
-#  else
+#if defined(__GLIBC__) && !__GLIBC_PREREQ(2, 29)
+    // Glibc versions prior to 2.29 don't support posix_spawn_file_actions_addchdir_np, impacting:
+    //  - Amazon Linux 2 (EoL mid-2025)
     return ENOSYS;
-#  endif
+#elif defined(__ANDROID__) && __ANDROID_API__ < 34
+    // Android versions prior to 14 (API level 34) don't support posix_spawn_file_actions_addchdir_np
+    return ENOSYS;
+#elif defined(__OpenBSD__) || defined(__QNX__)
+    // Currently missing as of:
+    //  - OpenBSD 7.5 (April 2024)
+    //  - QNX 8 (December 2023)
+    return ENOSYS;
+#elif defined(__GLIBC__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__ANDROID__) || defined(__musl__)
+    // Pre-standard posix_spawn_file_actions_addchdir_np version available in:
+    //  - Solaris 11.3 (October 2015)
+    //  - Glibc 2.29 (February 2019)
+    //  - macOS 10.15 (October 2019)
+    //  - musl 1.1.24 (October 2019)
+    //  - FreeBSD 13.1 (May 2022)
+    //  - Android 14 (October 2023)
+    return posix_spawn_file_actions_addchdir_np((posix_spawn_file_actions_t *)file_actions, path);
 #else
-    return ENOSYS;
+    // Standardized posix_spawn_file_actions_addchdir version (POSIX.1-2024, June 2024) available in:
+    //  - Solaris 11.4 (August 2018)
+    //  - NetBSD 10.0 (March 2024)
+    return posix_spawn_file_actions_addchdir((posix_spawn_file_actions_t *)file_actions, path);
 #endif
 }
 
 bool SPM_posix_spawn_file_actions_addchdir_np_supported() {
-#if defined(__GLIBC__)
-#  if __GLIBC_PREREQ(2, 29)
-    return true;
-#  else
+#if (defined(__GLIBC__) && !__GLIBC_PREREQ(2, 29)) || (defined(__OpenBSD__)) || (defined(__ANDROID__) && __ANDROID_API__ < 34) || (defined(__QNX__))
     return false;
-#  endif
 #else
-    return false;
+    return true;
 #endif
 }
 

--- a/Tests/TSCBasicTests/ProcessTests.swift
+++ b/Tests/TSCBasicTests/ProcessTests.swift
@@ -428,12 +428,7 @@ class ProcessTests: XCTestCase {
     }
 
     func testWorkingDirectory() throws {
-        guard #available(macOS 10.15, *) else {
-            // Skip this test since it's not supported in this OS.
-            return
-        }
-
-      #if os(Linux) || os(Android)
+      #if !os(Windows)
         guard SPM_posix_spawn_file_actions_addchdir_np_supported() else {
             // Skip this test since it's not supported in this OS.
             return


### PR DESCRIPTION
This will now be able to work correctly under FreeBSD, Android, musl, and so on.