### PR TITLE
build: use library directories instead of library names

### DIFF
--- a/Sources/TSCBasic/CMakeLists.txt
+++ b/Sources/TSCBasic/CMakeLists.txt
@@ -59,8 +59,8 @@ target_link_libraries(TSCBasic PRIVATE
   TSCLibc)
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   if(Foundation_FOUND)
-    target_link_libraries(TSCBasic PUBLIC
-      Foundation)
+    target_link_directories(TSCBasic PUBLIC
+      $<TARGET_LINKER_FILE_DIR:Foundation>)
   endif()
 endif()
 target_link_libraries(TSCBasic PRIVATE

--- a/Sources/TSCUtility/CMakeLists.txt
+++ b/Sources/TSCUtility/CMakeLists.txt
@@ -54,8 +54,8 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
     target_link_directories(TSCUtility PRIVATE /usr/local/lib)
   endif()
   if(Foundation_FOUND)
-    target_link_libraries(TSCUtility PUBLIC
-      FoundationNetworking)
+    target_link_directories(TSCUtility PUBLIC
+      $<TARGET_LINKER_FILE_DIR:FoundationNetworking>)
   endif()
 endif()
 # NOTE(compnerd) workaround for CMake not setting up include flags yet


### PR DESCRIPTION
`Foundation` was not being resolved to the target and instead would add `-lFoundation` to the linker invocation which is unnecessary due to the autolinking. Add the library search directory instead.