### PR TITLE
[6.2] Android: correct posix_spawn_file_actions_t typealias (#519)

### DIFF
--- a/Sources/TSCBasic/Process/Process.swift
+++ b/Sources/TSCBasic/Process/Process.swift
@@ -1316,7 +1316,7 @@ extension Process: Hashable {
 // MARK: - Private helpers
 
 #if !os(Windows)
-#if canImport(Darwin) || os(FreeBSD) || os(OpenBSD)
+#if canImport(Darwin) || canImport(Android) || os(FreeBSD) || os(OpenBSD)
 public typealias swiftpm_posix_spawn_file_actions_t = posix_spawn_file_actions_t?
 #else
 public typealias swiftpm_posix_spawn_file_actions_t = posix_spawn_file_actions_t


### PR DESCRIPTION
__Explanation:__ Get 6.2 building for Android again.

__Scope:__ Only affects Android

__Issue:__ None

__Original PR:__ #519

__Risk:__ None for any official platform

__Testing:__ Passed trunk and my Android CI

__Reviewer:__ @jakepetroules