### PR TITLE
OpenBSD 7.8 will require OpaquePointer for FILE.

### DIFF
--- a/Sources/TSCBasic/WritableByteStream.swift
+++ b/Sources/TSCBasic/WritableByteStream.swift
@@ -66,7 +66,7 @@ public extension WritableByteStream {
 // Public alias to the old name to not introduce API compatibility.
 public typealias OutputByteStream = WritableByteStream
 
-#if os(Android)
+#if os(Android) || os(OpenBSD)
 public typealias FILEPointer = OpaquePointer
 #else
 public typealias FILEPointer = UnsafeMutablePointer<FILE>


### PR DESCRIPTION
We changed Swift to use OpaquePointer in Glibc since OpenBSD 7.8 snapshots now hide the type information for FILE. Therefore, the types for the standard stdio streams should (regrettably) be OpaquePointer, due to the well-discussed issue of losing type information for forward-declared C types.

Subsequently, this means we should be using OpaquePointer here also.