### PR TITLE
Remove unnecessary type casting

### DIFF
--- a/Sources/TSCBasic/CMakeLists.txt
+++ b/Sources/TSCBasic/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(TSCBasic
   TemporaryFile.swift
   TerminalController.swift
   Thread.swift
+  "WinSDK+Overlay.swift"
   misc.swift)
 
 target_compile_options(TSCBasic PUBLIC

--- a/Sources/TSCBasic/Lock.swift
+++ b/Sources/TSCBasic/Lock.swift
@@ -95,11 +95,11 @@ public final class FileLock {
             let h: HANDLE = lockFile.pathString.withCString(encodedAs: UTF16.self, {
                 CreateFileW(
                     $0,
-                    UInt32(GENERIC_READ) | UInt32(GENERIC_WRITE),
-                    UInt32(FILE_SHARE_READ) | UInt32(FILE_SHARE_WRITE),
+                    GENERIC_READ | GENERIC_WRITE,
+                    FILE_SHARE_READ | FILE_SHARE_WRITE,
                     nil,
-                    DWORD(OPEN_ALWAYS),
-                    DWORD(FILE_ATTRIBUTE_NORMAL),
+                    OPEN_ALWAYS,
+                    FILE_ATTRIBUTE_NORMAL,
                     nil
                 )
             })
@@ -112,7 +112,7 @@ public final class FileLock {
         overlapped.Offset = 0
         overlapped.OffsetHigh = 0
         overlapped.hEvent = nil
-        var dwFlags = Int32(0)
+        var dwFlags: DWORD = 0
         switch type {
         case .exclusive: dwFlags |= LOCKFILE_EXCLUSIVE_LOCK
         case .shared: break
@@ -120,7 +120,7 @@ public final class FileLock {
         if !blocking {
             dwFlags |= LOCKFILE_FAIL_IMMEDIATELY
         }
-        if !LockFileEx(handle, DWORD(dwFlags), 0,
+        if !LockFileEx(handle, dwFlags, 0,
                        UInt32.max, UInt32.max, &overlapped) {
             throw ProcessLockError.unableToAquireLock(errno: Int32(GetLastError()))
         }

--- a/Sources/TSCBasic/Lock.swift
+++ b/Sources/TSCBasic/Lock.swift
@@ -93,15 +93,9 @@ public final class FileLock {
       #if os(Windows)
         if handle == nil {
             let h: HANDLE = lockFile.pathString.withCString(encodedAs: UTF16.self, {
-                CreateFileW(
-                    $0,
-                    UInt32(GENERIC_READ) | UInt32(GENERIC_WRITE),
-                    UInt32(FILE_SHARE_READ) | UInt32(FILE_SHARE_WRITE),
-                    nil,
-                    DWORD(OPEN_ALWAYS),
-                    DWORD(FILE_ATTRIBUTE_NORMAL),
-                    nil
-                )
+                CreateFileW($0, GENERIC_READ | GENERIC_WRITE,
+                            FILE_SHARE_READ | FILE_SHARE_WRITE, nil,
+                            OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, nil)
             })
             if h == INVALID_HANDLE_VALUE {
                 throw FileSystemError(errno: Int32(GetLastError()), lockFile)
@@ -114,14 +108,13 @@ public final class FileLock {
         overlapped.hEvent = nil
         var dwFlags: DWORD = 0
         switch type {
-        case .exclusive: dwFlags |= DWORD(LOCKFILE_EXCLUSIVE_LOCK)
+        case .exclusive: dwFlags |= LOCKFILE_EXCLUSIVE_LOCK
         case .shared: break
         }
         if !blocking {
-            dwFlags |= DWORD(LOCKFILE_FAIL_IMMEDIATELY)
+            dwFlags |= LOCKFILE_FAIL_IMMEDIATELY
         }
-        if !LockFileEx(handle, DWORD(dwFlags), 0,
-                       UInt32.max, UInt32.max, &overlapped) {
+        if !LockFileEx(handle, dwFlags, 0, UInt32.max, UInt32.max, &overlapped) {
             throw ProcessLockError.unableToAquireLock(errno: Int32(GetLastError()))
         }
       #else

--- a/Sources/TSCBasic/PathShims.swift
+++ b/Sources/TSCBasic/PathShims.swift
@@ -24,17 +24,17 @@ import Foundation
 public func resolveSymlinks(_ path: AbsolutePath) throws -> AbsolutePath {
 #if os(Windows)
     let handle: HANDLE = path.pathString.withCString(encodedAs: UTF16.self) {
-        CreateFileW($0, GENERIC_READ, DWORD(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE), nil,
-                    DWORD(OPEN_EXISTING), DWORD(FILE_FLAG_BACKUP_SEMANTICS), nil)
+        CreateFileW($0, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nil,
+                    OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nil)
     }
     if handle == INVALID_HANDLE_VALUE { return path }
     defer { CloseHandle(handle) }
 
     let dwLength: DWORD =
-        GetFinalPathNameByHandleW(handle, nil, 0, DWORD(VOLUME_NAME_DOS))
+        GetFinalPathNameByHandleW(handle, nil, 0, VOLUME_NAME_DOS)
     return try withUnsafeTemporaryAllocation(of: WCHAR.self, capacity: Int(dwLength)) {
         guard GetFinalPathNameByHandleW(handle, $0.baseAddress!, DWORD($0.count),
-                                        DWORD(VOLUME_NAME_DOS)) == dwLength - 1 else {
+                                        VOLUME_NAME_DOS) == dwLength - 1 else {
             throw FileSystemError(.unknownOSError, path)
         }
         _ = PathCchStripPrefix($0.baseAddress, $0.count)

--- a/Sources/TSCBasic/TerminalController.swift
+++ b/Sources/TSCBasic/TerminalController.swift
@@ -99,7 +99,7 @@ public final class TerminalController {
         guard hOut != INVALID_HANDLE_VALUE else { return nil }
         guard GetConsoleMode(hOut, &dwMode) else { return nil }
 
-        dwMode |= DWORD(ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+        dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING
         guard SetConsoleMode(hOut, dwMode) else { return nil }
 #endif
         self.stream = stream

--- a/Sources/TSCBasic/WinSDK+Overlay.swift
+++ b/Sources/TSCBasic/WinSDK+Overlay.swift
@@ -1,0 +1,140 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+#if os(Windows)
+
+import WinSDK
+
+@_transparent
+internal var CREATE_NEW_PROCESS_GROUP: DWORD {
+  DWORD(WinSDK.CREATE_NEW_PROCESS_GROUP)
+}
+
+@_transparent
+internal var CREATE_SUSPENDED: DWORD {
+  DWORD(WinSDK.CREATE_SUSPENDED)
+}
+
+@_transparent
+internal var ENABLE_VIRTUAL_TERMINAL_PROCESSING: DWORD {
+  DWORD(WinSDK.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+}
+
+@_transparent
+internal var FILE_ATTRIBUTE_NORMAL: DWORD {
+  DWORD(WinSDK.FILE_ATTRIBUTE_NORMAL)
+}
+
+@_transparent
+internal var FILE_FLAG_BACKUP_SEMANTICS: DWORD {
+  DWORD(WinSDK.FILE_FLAG_BACKUP_SEMANTICS)
+}
+
+@_transparent
+internal var FILE_FLAG_OVERLAPPED: DWORD {
+  DWORD(WinSDK.FILE_FLAG_OVERLAPPED)
+}
+
+@_transparent
+internal var FILE_LIST_DIRECTORY: DWORD {
+  DWORD(WinSDK.FILE_LIST_DIRECTORY)
+}
+
+@_transparent
+internal var FILE_NOTIFY_CHANGE_CREATION: DWORD {
+  DWORD(WinSDK.FILE_NOTIFY_CHANGE_CREATION)
+}
+
+@_transparent
+internal var FILE_NOTIFY_CHANGE_DIR_NAME: DWORD {
+  DWORD(WinSDK.FILE_NOTIFY_CHANGE_DIR_NAME)
+}
+
+@_transparent
+internal var FILE_NOTIFY_CHANGE_FILE_NAME: DWORD {
+  DWORD(WinSDK.FILE_NOTIFY_CHANGE_FILE_NAME)
+}
+
+@_transparent
+internal var FILE_NOTIFY_CHANGE_LAST_WRITE: DWORD {
+  DWORD(WinSDK.FILE_NOTIFY_CHANGE_LAST_WRITE)
+}
+
+@_transparent
+internal var FILE_NOTIFY_CHANGE_SIZE: DWORD {
+  DWORD(WinSDK.FILE_NOTIFY_CHANGE_SIZE)
+}
+
+@_transparent
+internal var FILE_SHARE_DELETE: DWORD {
+  DWORD(WinSDK.FILE_SHARE_DELETE)
+}
+
+@_transparent
+internal var FILE_SHARE_READ: DWORD {
+  DWORD(WinSDK.FILE_SHARE_READ)
+}
+
+@_transparent
+internal var FILE_SHARE_WRITE: DWORD {
+  DWORD(WinSDK.FILE_SHARE_WRITE)
+}
+
+@_transparent
+internal var GENERIC_READ: DWORD {
+  DWORD(WinSDK.GENERIC_READ)
+}
+
+@_transparent
+internal var GENERIC_WRITE: DWORD {
+  DWORD(WinSDK.GENERIC_WRITE)
+}
+
+@_transparent
+internal var JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE: DWORD {
+  DWORD(WinSDK.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE)
+}
+
+@_transparent
+internal var JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK: DWORD {
+  DWORD(WinSDK.JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK)
+}
+
+@_transparent
+internal var LOCKFILE_EXCLUSIVE_LOCK: DWORD {
+  DWORD(WinSDK.LOCKFILE_EXCLUSIVE_LOCK)
+}
+
+@_transparent
+internal var LOCKFILE_FAIL_IMMEDIATELY: DWORD {
+  DWORD(WinSDK.LOCKFILE_FAIL_IMMEDIATELY)
+}
+
+@_transparent
+internal var OPEN_ALWAYS: DWORD {
+  DWORD(WinSDK.OPEN_ALWAYS)
+}
+
+@_transparent
+internal var OPEN_EXISTING: DWORD {
+  DWORD(WinSDK.OPEN_EXISTING)
+}
+
+@_transparent
+internal var VOLUME_NAME_DOS: DWORD {
+  DWORD(WinSDK.VOLUME_NAME_DOS)
+}
+
+@_transparent
+internal var WAIT_TIMEOUT: DWORD {
+  DWORD(WinSDK.WAIT_TIMEOUT)
+}
+
+#endif

--- a/Sources/TSCBasic/misc.swift
+++ b/Sources/TSCBasic/misc.swift
@@ -118,8 +118,7 @@ public func exec(path: String, args: [String]) throws -> Never {
         }
 
         var eliLimits: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = JOBOBJECT_EXTENDED_LIMIT_INFORMATION()
-        eliLimits.BasicLimitInformation.LimitFlags =
-        DWORD(JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE) | DWORD(JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK)
+        eliLimits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE | JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK
         if !SetInformationJobObject(hJob, JobObjectExtendedLimitInformation, &eliLimits,
                                     DWORD(MemoryLayout<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>.size)) {
             throw SystemError.exec(Int32(GetLastError()), path: path, args: args)
@@ -135,7 +134,7 @@ public func exec(path: String, args: [String]) throws -> Never {
             if !CreateProcessW(nil,
                                UnsafeMutablePointer<WCHAR>(mutating: pwszCommandLine),
                                nil, nil, false,
-                               DWORD(CREATE_SUSPENDED) | DWORD(CREATE_NEW_PROCESS_GROUP),
+                               CREATE_SUSPENDED | CREATE_NEW_PROCESS_GROUP,
                                nil, nil, &siInfo, &piInfo) {
                 throw SystemError.exec(Int32(GetLastError()), path: path, args: args)
             }

--- a/Sources/TSCUtility/CMakeLists.txt
+++ b/Sources/TSCUtility/CMakeLists.txt
@@ -27,9 +27,9 @@ add_library(TSCUtility
   Verbosity.swift
   Version.swift
   Versioning.swift
+  WinSDK+Overlay.swift
   dlopen.swift
-  misc.swift
-)
+  misc.swift)
 target_link_libraries(TSCUtility PUBLIC
   TSCBasic)
 target_link_libraries(TSCUtility PRIVATE

--- a/Sources/TSCUtility/FSWatch.swift
+++ b/Sources/TSCUtility/FSWatch.swift
@@ -191,14 +191,13 @@ public final class RDCWatcher {
 
         self.watches = paths.map {
             $0.pathString.withCString(encodedAs: UTF16.self) {
-                let dwDesiredAccess: DWORD = DWORD(FILE_LIST_DIRECTORY)
-                let dwShareMode: DWORD = DWORD(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
-                let dwCreationDisposition: DWORD = DWORD(OPEN_EXISTING)
-                let dwFlags: DWORD = DWORD(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED)
-
                 let handle: HANDLE =
-                        CreateFileW($0, dwDesiredAccess, dwShareMode, nil,
-                                    dwCreationDisposition, dwFlags, nil)
+                    CreateFileW($0, FILE_LIST_DIRECTORY,
+                                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                                nil,
+                                OPEN_EXSTING,
+                                FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED,
+                                nil)
                 assert(!(handle == INVALID_HANDLE_VALUE))
 
                 let dwSize: DWORD = GetFinalPathNameByHandleW(handle, nil, 0, 0)
@@ -220,11 +219,11 @@ public final class RDCWatcher {
                 guard let watch = watch else { return }
 
                 while true {
-                    let dwNotifyFilter: DWORD = DWORD(FILE_NOTIFY_CHANGE_FILE_NAME)
-                                              | DWORD(FILE_NOTIFY_CHANGE_DIR_NAME)
-                                              | DWORD(FILE_NOTIFY_CHANGE_SIZE)
-                                              | DWORD(FILE_NOTIFY_CHANGE_LAST_WRITE)
-                                              | DWORD(FILE_NOTIFY_CHANGE_CREATION)
+                    let dwNotifyFilter = FILE_NOTIFY_CHANGE_FILE_NAME
+                                       | FILE_NOTIFY_CHANGE_DIR_NAME
+                                       | FILE_NOTIFY_CHANGE_SIZE
+                                       | FILE_NOTIFY_CHANGE_LAST_WRITE
+                                       | FILE_NOTIFY_CHANGE_CREATION
                     var dwBytesReturned: DWORD = 0
                     if !ReadDirectoryChangesW(watch.hDirectory, &watch.buffer,
                                               DWORD(watch.buffer.count * MemoryLayout<DWORD>.stride),
@@ -237,7 +236,7 @@ public final class RDCWatcher {
                     switch WaitForMultipleObjects(2, &handles.0, false, INFINITE) {
                         case WAIT_OBJECT_0 + 1:
                             break
-                        case DWORD(WAIT_TIMEOUT):  // Spurious Wakeup?
+                        case WAIT_TIMEOUT:  // Spurious Wakeup?
                             continue
                         case WAIT_FAILED:   // Failure
                             fallthrough

--- a/Sources/TSCUtility/FSWatch.swift
+++ b/Sources/TSCUtility/FSWatch.swift
@@ -191,14 +191,9 @@ public final class RDCWatcher {
 
         self.watches = paths.map {
             $0.pathString.withCString(encodedAs: UTF16.self) {
-                let dwDesiredAccess: DWORD = DWORD(FILE_LIST_DIRECTORY)
-                let dwShareMode: DWORD = DWORD(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
-                let dwCreationDisposition: DWORD = DWORD(OPEN_EXISTING)
-                let dwFlags: DWORD = DWORD(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED)
-
                 let handle: HANDLE =
-                        CreateFileW($0, dwDesiredAccess, dwShareMode, nil,
-                                    dwCreationDisposition, dwFlags, nil)
+                    CreateFileW($0, FILE_LIST_DIRECTORY, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                                nil, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED, nil)
                 assert(!(handle == INVALID_HANDLE_VALUE))
 
                 let dwSize: DWORD = GetFinalPathNameByHandleW(handle, nil, 0, 0)
@@ -220,11 +215,11 @@ public final class RDCWatcher {
                 guard let watch = watch else { return }
 
                 while true {
-                    let dwNotifyFilter: DWORD = DWORD(FILE_NOTIFY_CHANGE_FILE_NAME)
-                                              | DWORD(FILE_NOTIFY_CHANGE_DIR_NAME)
-                                              | DWORD(FILE_NOTIFY_CHANGE_SIZE)
-                                              | DWORD(FILE_NOTIFY_CHANGE_LAST_WRITE)
-                                              | DWORD(FILE_NOTIFY_CHANGE_CREATION)
+                    let dwNotifyFilter = FILE_NOTIFY_CHANGE_FILE_NAME
+                                       | FILE_NOTIFY_CHANGE_DIR_NAME
+                                       | FILE_NOTIFY_CHANGE_SIZE
+                                       | FILE_NOTIFY_CHANGE_LAST_WRITE
+                                       | FILE_NOTIFY_CHANGE_CREATION
                     var dwBytesReturned: DWORD = 0
                     if !ReadDirectoryChangesW(watch.hDirectory, &watch.buffer,
                                               DWORD(watch.buffer.count * MemoryLayout<DWORD>.stride),
@@ -237,7 +232,7 @@ public final class RDCWatcher {
                     switch WaitForMultipleObjects(2, &handles.0, false, INFINITE) {
                         case WAIT_OBJECT_0 + 1:
                             break
-                        case DWORD(WAIT_TIMEOUT):  // Spurious Wakeup?
+                        case WAIT_TIMEOUT:  // Spurious Wakeup?
                             continue
                         case WAIT_FAILED:   // Failure
                             fallthrough

--- a/Sources/TSCUtility/WinSDK+Overlay.swift
+++ b/Sources/TSCUtility/WinSDK+Overlay.swift
@@ -1,0 +1,1 @@
+../TSCBasic/WinSDK+Overlay.swift


### PR DESCRIPTION
The compiler now imports these as their canonical type, allowing us to directly use without the explicit type cast.